### PR TITLE
Export styles.css for Astro framework support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 				"default": "./dist/index.js"
 			},
 			"default": "./dist/index.js"
-		}
+		},
+		"./dist/styles.css": "./dist/styles.css"
 	},
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Adds explicit CSS file export to package.json to support frameworks like Astro that require separate style imports.

## Changes

  - Added `"./dist/styles.css": "./dist/styles.css"` export path to package.json
  - Replaced tabs with spaces

## Motivation

Frameworks like Astro (especially when using View Transitions) need to import CSS files separately from the component library. This export allows users to explicitly import the Sileo styles:

```js
import 'sileo/dist/styles.css'
```

Without this export, users would have to rely on deep imports or workarounds to access the stylesheet.
