### PR TITLE
fix: scope prefers-reduced-motion CSS to Sileo viewport only

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -456,9 +456,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	*,
-	*::before,
-	*::after {
+	[data-sileo-viewport],
+	[data-sileo-viewport] *,
+	[data-sileo-viewport] *::before,
+	[data-sileo-viewport] *::after {
 		animation-duration: 0.01ms;
 		animation-iteration-count: 1;
 		transition-duration: 0.01ms;


### PR DESCRIPTION
## Summary

The `@media (prefers-reduced-motion: reduce)` block in `styles.css` uses an unscoped `*` selector that disables **all** CSS animations and transitions across the entire page — not just Sileo toasts.

## Problem

When a user has `prefers-reduced-motion: reduce` enabled, importing Sileo's stylesheet causes every animation in the host app to break:

```css
/* Current — affects entire page */
@media (prefers-reduced-motion: reduce) {
  *, *::before, *::after {
    animation-duration: 0.01ms;
    animation-iteration-count: 1;
    transition-duration: 0.01ms;
  }
}
```

Any app using page transitions, animated modals, loading spinners, or third-party component libraries will have their animations killed.

## Solution

Scope the reduced-motion overrides to Sileo's own DOM tree using the `[data-sileo-viewport]` attribute selector:

```css
@media (prefers-reduced-motion: reduce) {
  [data-sileo-viewport],
  [data-sileo-viewport] *,
  [data-sileo-viewport] *::before,
  [data-sileo-viewport] *::after {
    animation-duration: 0.01ms;
    animation-iteration-count: 1;
    transition-duration: 0.01ms;
  }
}
```

## Files Changed

| File | Changes |
|------|---------|
| `src/styles.css` (lines 458-466) | Scope `*` selector to `[data-sileo-viewport]` descendants |

## Testing

1. Import Sileo in an app that has CSS animations (e.g., Tailwind `animate-spin`)
2. Enable `prefers-reduced-motion: reduce` in OS accessibility settings
3. **Before fix:** All app animations break
4. **After fix:** Only Sileo toast animations respect the reduced-motion preference

## Backward Compatibility

- No breaking changes
- Sileo toast animations still respect reduced-motion preference
- Host app animations are no longer affected

Fixes #19