### PR TITLE
feat: add dark/light/system theme support

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -464,3 +464,13 @@
 		transition-duration: 0.01ms;
 	}
 }
+
+/* --------------------------------- Themes -------------------------------- */
+
+[data-sileo-viewport][data-theme="dark"] [data-sileo-description] {
+	color: rgba(255, 255, 255, 0.8);
+}
+
+[data-sileo-viewport][data-theme="light"] [data-sileo-description] {
+	color: rgba(0, 0, 0, 0.7);
+}


### PR DESCRIPTION
## Summary

Add a `theme` prop to `<Toaster>` that automatically sets the toast fill color and description text color based on the active theme. Supports `'light'`, `'dark'`, and `'system'` (auto-detects via `prefers-color-scheme`).

## Problem

Sileo defaults to a white fill (`#FFFFFF`), making toasts invisible or unreadable in dark mode apps. There's no built-in way to adapt to the user's color scheme.

## Solution

### New `theme` prop on `SileoToasterProps`

```tsx
<Toaster theme="dark" />   // dark fill + light text
<Toaster theme="light" />  // white fill + dark text
<Toaster theme="system" /> // auto-detects from OS preference
```

| Theme | Fill Color | Description Text |
|-------|-----------|-----------------|
| `light` | `#FFFFFF` | `rgba(0, 0, 0, 0.7)` |
| `dark` | `#1a1a1a` | `rgba(255, 255, 255, 0.8)` |
| `system` | Auto-detects via `prefers-color-scheme` | Matches theme |

### Implementation details

- **`useResolvedTheme` hook** — listens to `matchMedia('(prefers-color-scheme: dark)')` changes when `theme='system'`
- **`THEME_FILLS` map** — maps resolved theme to fill color, applied as default in `store.options`
- **`data-theme` attribute** — set on `[data-sileo-viewport]` for CSS-based theme targeting
- **CSS rules** — `[data-theme="dark"]` / `[data-theme="light"]` for description text color

### Files Changed

| File | Changes |
|------|---------|
| `src/toast.tsx` | `theme` prop, `useResolvedTheme` hook, `THEME_FILLS`, `data-theme` attr |
| `src/styles.css` | `[data-theme]` CSS rules for description text color |

## Backward Compatibility

- `theme` prop is optional — omitting it preserves existing behavior (white fill, no `data-theme` attr)
- Individual `fill` overrides on toast calls still take precedence

## Testing

1. Set `theme="system"` and toggle OS dark/light mode — fill and text color should switch automatically
2. Set `theme="dark"` — verify description text is readable (light text on dark background)
3. Omit `theme` prop — verify behavior is unchanged from current release

Closes #20