### PR TITLE
fix: auto-generate unique IDs so multiple toasts display simultaneously

### DIFF
--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -131,7 +131,7 @@ const createToast = (options: InternalSileoOptions) => {
 	const live = store.toasts.filter((t) => !t.exiting);
 	const merged = mergeOptions(options);
 
-	const id = merged.id ?? "sileo-default";
+	const id = merged.id ?? generateId();
 	const prev = live.find((t) => t.id === id);
 	const item = buildSileoItem(merged, id, prev?.position);
 


### PR DESCRIPTION
## Summary

Change the default toast ID from the hardcoded `"sileo-default"` to an auto-generated unique ID, so multiple toasts can display simultaneously.

## Problem

In `createToast()`, when no `id` is provided, it defaults to `"sileo-default"`:

```ts
const id = merged.id ?? "sileo-default";
```

This means every toast without an explicit `id` shares the same identifier. Calling `sileo.success(...)` twice in quick succession **replaces** the first toast instead of showing two separate notifications.

```ts
// Only shows ONE toast — the second replaces the first
sileo.success({ title: "Toast 1" });
sileo.success({ title: "Toast 2" });
```

This is unexpected — most toast libraries (Sonner, react-hot-toast, etc.) show each call as a separate notification.

## Solution

Use the existing `generateId()` helper (already defined in the file) as the default:

```ts
// Before
const id = merged.id ?? "sileo-default";

// After
const id = merged.id ?? generateId();
```

`generateId()` produces IDs like `"3-m1abc2d-x7k9f2"` (counter + timestamp + random), ensuring uniqueness.

## Files Changed

| File | Changes |
|------|---------|
| `src/toast.tsx` (line 134) | Replace `"sileo-default"` with `generateId()` |

## Backward Compatibility

- Explicit `id` usage still works exactly as before (deduplicated)
- Only affects the default case where no `id` is provided
- Users who want the old "replace" behavior can pass a fixed `id`:

```ts
// Still deduplicates when you pass an explicit id
sileo.success({ title: "Toast 1", id: "my-toast" });
sileo.success({ title: "Toast 2", id: "my-toast" }); // Replaces first
```

## Testing

```ts
// After fix: shows TWO separate toasts
sileo.success({ title: "Toast 1" });
sileo.success({ title: "Toast 2" });
```