### PR TITLE
feat: add optional close button for toast dismissal

### DIFF
--- a/src/sileo.tsx
+++ b/src/sileo.tsx
@@ -65,6 +65,7 @@ interface SileoProps {
 	canExpand?: boolean;
 	interruptKey?: string;
 	refreshKey?: string;
+	closeButton?: boolean;
 	onMouseEnter?: MouseEventHandler<HTMLButtonElement>;
 	onMouseLeave?: MouseEventHandler<HTMLButtonElement>;
 	onDismiss?: () => void;
@@ -133,6 +134,7 @@ export const Sileo = memo(function Sileo({
 	canExpand,
 	interruptKey,
 	refreshKey,
+	closeButton = false,
 	onMouseEnter,
 	onMouseLeave,
 	onDismiss,
@@ -651,6 +653,29 @@ export const Sileo = memo(function Sileo({
 					)}
 				</div>
 			</div>
+
+			{closeButton && onDismiss && (
+				<div
+					data-sileo-close
+					role="button"
+					tabIndex={0}
+					aria-label="Close notification"
+					onClick={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+						onDismiss();
+					}}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter' || e.key === ' ') {
+							e.preventDefault();
+							e.stopPropagation();
+							onDismiss();
+						}
+					}}
+				>
+					<X />
+				</div>
+			)}
 
 			{hasDesc && (
 				<div data-sileo-content data-edge={expand} data-visible={open}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -455,6 +455,36 @@
 	}
 }
 
+/* ----------------------------- Close Button ------------------------------ */
+
+[data-sileo-close] {
+	position: absolute;
+	top: 0;
+	right: 0;
+	z-index: 30;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--sileo-height);
+	height: var(--sileo-height);
+	padding: 0;
+	border: 0;
+	background: transparent;
+	cursor: pointer;
+	pointer-events: auto;
+	color: rgba(0, 0, 0, 0.4);
+	opacity: 0;
+	transition: opacity 150ms ease;
+}
+
+[data-sileo-toast]:hover [data-sileo-close] {
+	opacity: 1;
+}
+
+[data-sileo-close]:hover {
+	color: rgba(0, 0, 0, 0.7);
+}
+
 @media (prefers-reduced-motion: reduce) {
 	*,
 	*::before,

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -47,6 +47,7 @@ export interface SileoToasterProps {
 	position?: SileoPosition;
 	offset?: SileoOffsetValue | SileoOffsetConfig;
 	options?: Partial<SileoOptions>;
+	closeButton?: boolean;
 }
 
 /* ------------------------------ Global State ------------------------------ */
@@ -218,6 +219,7 @@ export function Toaster({
 	position = "top-right",
 	offset,
 	options,
+	closeButton = false,
 }: SileoToasterProps) {
 	const [toasts, setToasts] = useState<SileoItem[]>(store.toasts);
 	const [activeId, setActiveId] = useState<string>();
@@ -423,6 +425,7 @@ export function Toaster({
 									onMouseEnter={h.enter}
 									onMouseLeave={h.leave}
 									onDismiss={h.dismiss}
+									closeButton={closeButton}
 								/>
 							);
 						})}


### PR DESCRIPTION
## Summary

Add a `closeButton` prop to `<Toaster>` that renders an X dismiss button on each toast, visible on hover. This provides an alternative to swipe-to-dismiss for desktop users.

## Problem

Currently the only way to dismiss a toast (besides waiting for auto-dismiss) is swiping. Desktop users expect a close button, especially for sticky toasts (`duration: null`) that don't auto-dismiss.

## Solution

### New `closeButton` prop

```tsx
<Toaster closeButton />
```

When enabled, each toast renders an X button (using the existing `X` icon) in the top-right corner. The button:
- Is hidden by default, fades in on toast hover
- Calls `onDismiss()` on click
- Is fully accessible: `role="button"`, `tabIndex`, `aria-label`, keyboard support (Enter/Space)
- Does not interfere with swipe-to-dismiss

### CSS

```css
[data-sileo-close] {
  position: absolute;
  top: 0; right: 0; z-index: 30;
  opacity: 0;
  transition: opacity 150ms ease;
}
[data-sileo-toast]:hover [data-sileo-close] { opacity: 1; }
```

## Files Changed

| File | Changes |
|------|---------|
| `src/toast.tsx` | Add `closeButton` prop to `SileoToasterProps`, pass to `<Sileo>` |
| `src/sileo.tsx` | Accept `closeButton` prop, render X button with a11y attributes |
| `src/styles.css` | Add `[data-sileo-close]` styles with hover reveal |

## Backward Compatibility

- `closeButton` defaults to `false` — no visual change unless opted in
- Swipe-to-dismiss still works alongside the button

## Testing

1. `<Toaster closeButton />` — hover over a toast, X button should fade in
2. Click X — toast should dismiss
3. Tab to button, press Enter — should dismiss
4. Verify swipe-to-dismiss still works
5. Without `closeButton` prop — verify no X button appears