### PR TITLE
feat: add optional Sonner-compatible API wrapper

### DIFF
--- a/src/compat.ts
+++ b/src/compat.ts
@@ -1,0 +1,58 @@
+import { sileo } from "./toast";
+import type { ReactNode } from "react";
+import type { SileoOptions } from "./types";
+
+interface SonnerCompatOptions {
+	description?: ReactNode | string;
+	duration?: number | null;
+	action?: { label: string; onClick: () => void };
+	id?: string;
+}
+
+function mapOptions(
+	msg: string | ReactNode,
+	opts?: SonnerCompatOptions,
+): SileoOptions & { id?: string } {
+	const title = typeof msg === "string" ? msg : "Notification";
+	const description = typeof msg !== "string" ? msg : opts?.description;
+	return {
+		title,
+		description,
+		duration:
+			opts?.duration === Infinity
+				? null
+				: opts?.duration === undefined
+					? undefined
+					: opts.duration,
+		button: opts?.action
+			? { title: opts.action.label, onClick: opts.action.onClick }
+			: undefined,
+		id: opts?.id,
+	};
+}
+
+type ToastFn = {
+	(msg: string | ReactNode, opts?: SonnerCompatOptions): string;
+	success: (msg: string | ReactNode, opts?: SonnerCompatOptions) => string;
+	error: (msg: string | ReactNode, opts?: SonnerCompatOptions) => string;
+	warning: (msg: string | ReactNode, opts?: SonnerCompatOptions) => string;
+	info: (msg: string | ReactNode, opts?: SonnerCompatOptions) => string;
+	dismiss: typeof sileo.dismiss;
+	promise: typeof sileo.promise;
+};
+
+const _toast = (msg: string | ReactNode, opts?: SonnerCompatOptions) =>
+	sileo.show(mapOptions(msg, opts));
+
+export const toast: ToastFn = Object.assign(_toast, {
+	success: (msg: string | ReactNode, opts?: SonnerCompatOptions) =>
+		sileo.success(mapOptions(msg, opts)),
+	error: (msg: string | ReactNode, opts?: SonnerCompatOptions) =>
+		sileo.error(mapOptions(msg, opts)),
+	warning: (msg: string | ReactNode, opts?: SonnerCompatOptions) =>
+		sileo.warning(mapOptions(msg, opts)),
+	info: (msg: string | ReactNode, opts?: SonnerCompatOptions) =>
+		sileo.info(mapOptions(msg, opts)),
+	dismiss: sileo.dismiss,
+	promise: sileo.promise,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@
 import "./styles.css";
 
 export { sileo, Toaster } from "./toast";
+export type { SileoToasterProps } from "./toast";
+export { toast } from "./compat";
 export type {
 	SileoButton,
 	SileoOptions,


### PR DESCRIPTION
## Summary

Add an optional `toast` export that provides a Sonner-compatible API, making migration from Sonner to Sileo a simple import change.

## Problem

Sileo uses a different API shape than Sonner:

```ts
// Sonner
toast.success('Saved!', { description: 'Your changes were saved.' })

// Sileo
sileo.success({ title: 'Saved!', description: 'Your changes were saved.' })
```

Projects migrating from Sonner need to rewrite every toast call.

## Solution

New `src/compat.ts` providing a callable `toast` with method variants:

```ts
import { toast } from 'sileo';

// Direct call (like Sonner's default)
toast('Hello');

// Typed calls
toast.success('Saved!', { description: 'Changes saved.' });
toast.error('Failed', { duration: 5000 });
toast.warning('Careful', { action: { label: 'Undo', onClick: undo } });

// Also available
toast.dismiss(id);
toast.promise(asyncFn, { loading, success, error });
```

### Option Mapping

| Sonner | Sileo |
|--------|-------|
| First arg (string) | `title` |
| `opts.description` | `description` |
| `opts.duration` | `duration` (`Infinity` → `null` for sticky toasts) |
| `opts.action.label` / `onClick` | `button.title` / `onClick` |
| `opts.id` | `id` |

## Files Changed

| File | Changes |
|------|---------|
| `src/compat.ts` | New file — Sonner-compatible API wrapper |
| `src/index.ts` | Export `toast` from compat, export `SileoToasterProps` type |

## Backward Compatibility

- Additive only — no changes to existing `sileo` API
- `toast` is a new named export alongside the existing `sileo` export
- Projects not using Sonner can ignore this entirely

## Testing

```ts
import { toast } from 'sileo';

toast.success('It works!');
toast.error('Oops', { description: 'Something broke', duration: 8000 });
toast('Plain notification');
```

---

> **Note:** This could alternatively live in a separate `sileo-compat` package if you prefer to keep the core package minimal. Happy to adjust the approach.