### PR TITLE
feat: add toast navigation

### DIFF
--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -66,3 +66,15 @@ export const Check = () => (
 		<path d="M20 6 9 17l-5-5" />
 	</Icon>
 );
+
+export const ChevronLeft = () => (
+	<Icon title="Previous">
+		<path d="m15 18-6-6 6-6" />
+	</Icon>
+);
+
+export const ChevronRight = () => (
+	<Icon title="Next">
+		<path d="m9 18 6-6-6-6" />
+	</Icon>
+);

--- a/src/sileo.tsx
+++ b/src/sileo.tsx
@@ -26,6 +26,8 @@ import {
 import {
 	ArrowRight,
 	Check,
+	ChevronLeft,
+	ChevronRight,
 	CircleAlert,
 	LifeBuoy,
 	LoaderCircle,
@@ -68,6 +70,9 @@ interface SileoProps {
 	onMouseEnter?: MouseEventHandler<HTMLButtonElement>;
 	onMouseLeave?: MouseEventHandler<HTMLButtonElement>;
 	onDismiss?: () => void;
+	navIndex?: number;
+	navTotal?: number;
+	onNavigate?: (dir: -1 | 1) => void;
 }
 
 /* ---------------------------------- Icons --------------------------------- */
@@ -136,6 +141,9 @@ export const Sileo = memo(function Sileo({
 	onMouseEnter,
 	onMouseLeave,
 	onDismiss,
+	navIndex,
+	navTotal,
+	onNavigate,
 }: SileoProps) {
 	const next: View = useMemo(
 		() => ({ title, description, state, icon, styles, button, fill }),
@@ -385,6 +393,8 @@ export const Sileo = memo(function Sileo({
 
 	/* ------------------------------ Derived values ---------------------------- */
 
+	const showNav = navTotal !== undefined && navTotal > 1;
+
 	const minExpanded = HEIGHT * MIN_EXPAND_RATIO;
 	const rawExpanded = hasDesc
 		? Math.max(minExpanded, HEIGHT + contentHeight)
@@ -398,7 +408,8 @@ export const Sileo = memo(function Sileo({
 	const expanded = open ? rawExpanded : frozenExpandedRef.current;
 	const svgHeight = hasDesc ? Math.max(expanded, minExpanded) : HEIGHT;
 	const expandedContent = Math.max(0, expanded - HEIGHT);
-	const resolvedPillWidth = Math.max(pillWidth || HEIGHT, HEIGHT);
+	const navExtra = showNav ? 50 : 0;
+	const resolvedPillWidth = Math.max(pillWidth || HEIGHT, HEIGHT) + navExtra;
 	const pillHeight = HEIGHT + blur * 3;
 
 	const pillX =
@@ -548,6 +559,7 @@ export const Sileo = memo(function Sileo({
 			if (exiting || !onDismiss) return;
 			const target = e.target as HTMLElement;
 			if (target.closest("[data-sileo-button]")) return;
+			if (target.closest("[data-sileo-nav]")) return;
 			pointerStartRef.current = e.clientY;
 			e.currentTarget.setPointerCapture(e.pointerId);
 			const el = buttonRef.current;
@@ -656,6 +668,30 @@ export const Sileo = memo(function Sileo({
 						</div>
 					)}
 				</div>
+				{showNav && (
+					<div data-sileo-nav>
+						<button
+							type="button"
+							onClick={() => onNavigate?.(-1)}
+							disabled={navIndex === 0}
+							aria-label="Previous notification"
+						>
+							<ChevronLeft />
+						</button>
+						<button
+							type="button"
+							onClick={() => onNavigate?.(1)}
+							disabled={
+								navIndex !== undefined &&
+								navTotal !== undefined &&
+								navIndex >= navTotal - 1
+							}
+							aria-label="Next notification"
+						>
+							<ChevronRight />
+						</button>
+					</div>
+				)}
 			</div>
 
 			{hasDesc && (

--- a/src/styles.css
+++ b/src/styles.css
@@ -149,14 +149,14 @@
 	overflow: hidden;
 	left: var(--_px, 0px);
 	transform: var(--_ht);
-	max-width: var(--_pw);
+	width: var(--_pw);
 }
 
 [data-sileo-toast][data-ready="true"] [data-sileo-header] {
 	transition:
 		transform var(--sileo-duration) var(--sileo-spring-easing),
 		left var(--sileo-duration) var(--sileo-spring-easing),
-		max-width var(--sileo-duration) var(--sileo-spring-easing);
+		width var(--sileo-duration) var(--sileo-spring-easing);
 }
 
 [data-sileo-header][data-edge="top"] {
@@ -446,6 +446,42 @@
 	left: 50%;
 	transform: translateX(-50%);
 	align-items: center;
+}
+
+/* ------------------------------ Navigation -------------------------------- */
+
+[data-sileo-nav] {
+	display: flex;
+	align-items: center;
+	gap: 0.125rem;
+	margin-left: auto;
+	flex-shrink: 0;
+	color: #fff;
+	pointer-events: auto;
+	user-select: none;
+}
+
+[data-sileo-nav] button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.5rem;
+	height: 1.5rem;
+	border: 0;
+	border-radius: 9999px;
+	background: transparent;
+	cursor: pointer;
+	color: inherit;
+	padding: 0;
+}
+
+[data-sileo-nav] button:not(:disabled):hover {
+	background-color: rgba(255, 255, 255, 0.12);
+}
+
+[data-sileo-nav] button:disabled {
+	opacity: 0.3;
+	cursor: default;
 }
 
 @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
- Add `< >` nav arrows embedded inside the pill to cycle through multiple simultaneous toasts per position
- Add `navigation` prop on `Toaster` to opt-in (default false)
- Auto-reset selection to newest toast when a new one arrives