### PR TITLE
fix: Fix toast identity race handling

### DIFF
--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -81,13 +81,19 @@ const timeoutKey = (t: SileoItem) => `${t.id}:${t.instanceId}`;
 const dismissToast = (id: string) => {
 	const item = store.toasts.find((t) => t.id === id);
 	if (!item || item.exiting) return;
+	const { instanceId } = item;
 
 	store.update((prev) =>
-		prev.map((t) => (t.id === id ? { ...t, exiting: true } : t)),
+		prev.map((t) =>
+			t.id === id && t.instanceId === instanceId ? { ...t, exiting: true } : t,
+		),
 	);
 
 	setTimeout(
-		() => store.update((prev) => prev.filter((t) => t.id !== id)),
+		() =>
+			store.update((prev) =>
+				prev.filter((t) => !(t.id === id && t.instanceId === instanceId)),
+			),
 		EXIT_DURATION,
 	);
 };
@@ -132,7 +138,7 @@ const createToast = (options: InternalSileoOptions) => {
 	const live = store.toasts.filter((t) => !t.exiting);
 	const merged = mergeOptions(options);
 
-	const id = merged.id ?? "sileo-default";
+	const id = merged.id ?? generateId();
 	const prev = live.find((t) => t.id === id);
 	const item = buildSileoItem(merged, id, prev?.position);
 


### PR DESCRIPTION
This PR fixes two high-severity toast identity issues:

- Unnamed toasts now get unique generated ids instead of sharing a constant default id.
- Dismiss now targets the exact `(id, instanceId)` pair, so delayed removal cannot delete a newer toast with the same id.

## Changes
- Updated toast creation to use a unique id when `id` is not provided.
- Updated dismiss flow to:
  - capture the current `instanceId`
  - mark exiting only for that specific instance
  - remove only that specific instance after exit timeout

## Result
- Multiple unnamed toasts no longer overwrite each other.
- Recreated toasts with the same `id` are safe from stale dismiss timers.
